### PR TITLE
Emphasis in blockquote

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -397,6 +397,10 @@ blockquote {
     font-style: italic;
 }
 
+blockquote em {
+    font-style: normal;
+}
+
 blockquote p {
     opacity: 0.8;
 }


### PR DESCRIPTION
Since quotations are italicized by default (really nice!), we need to find a way to highlight the emphasis that would normally be shown in italics.