### PR TITLE
Feature: Add image previews to the upload interface in post and page editor.

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -480,16 +480,28 @@ button.save:hover {
 
 .image-list li {
     margin-bottom: 1rem;
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    align-items: center;
 }
 
 .image-list code {
     display: inline-block;
     word-break: break-all;
     font-size: 1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-wrap: nowrap;
 }
 
 .image-list button {
     font-size: 0.8rem;
+    text-wrap: nowrap;
+}
+
+.image-list .image-list-preview {
+    object-fit: cover;
 }
 
 .inline-form {

--- a/admin/edit-page.php
+++ b/admin/edit-page.php
@@ -235,6 +235,9 @@ require __DIR__ . '/../includes/admin-head.php';
                             <ul class="image-list">
                             <?php foreach ($images as $image): ?>
                                 <li>
+                                    <img src="<?= $image[
+                                        "url"
+                                    ] ?>" width="30" height="30" class="image-list-preview"/>
                                     <code><?= e($image['filename']) ?></code>
                                     <button type="button" class="link-button copy-markdown" data-markdown="<?= e($image['markdown']) ?>"><svg class="icon" aria-hidden="true"><use href="#icon-copy"></use></svg> <?= e(t('admin.editor.copy')) ?></button>
                                 <form method="post" action="<?= base_path() ?>/admin/delete-image.php" class="inline-form" onsubmit="return confirm('<?= e(t('admin.page_editor.delete_image_confirm')) ?>');">

--- a/admin/edit-post.php
+++ b/admin/edit-post.php
@@ -315,6 +315,9 @@ require __DIR__ . '/../includes/admin-head.php';
                             <ul class="image-list">
                             <?php foreach ($images as $image): ?>
                                 <li>
+                                    <img src="<?= $image[
+                                        "url"
+                                    ] ?>" width="30" height="30" class="image-list-preview"/>
                                     <code><?= e($image['filename']) ?></code>
                                     <button type="button" class="link-button copy-markdown" data-markdown="<?= e($image['markdown']) ?>"><svg class="icon" aria-hidden="true"><use href="#icon-copy"></use></svg> <?= e(t('admin.editor.copy')) ?></button>
                                 <form method="post" action="<?= base_path() ?>/admin/delete-image.php" class="inline-form" onsubmit="return confirm('<?= e(t('admin.post_editor.delete_image_confirm')) ?>');">


### PR DESCRIPTION
**Overview**

Adds a 30x30 image preview to the upload interface, making it easier to manage images in posts/pages with numerous images uploaded that have generic names (ie straight from a camera).

**Changes**

- Modified `admin.css` to facilitate image preview. Note: filename will now overflow hide with ellipsis so as to prevent wrapping on the row, this typically means the file extension will be cut off (see screenshot). 
- Modified `edit-page.php` and `edit-post.php` to add preview
- Adds a 30x30 image preview to the upload interface, making it easier to manage images in posts/pages with numerous images uploaded.


**Screenshot**

<img width="545" height="481" alt="image" src="https://github.com/user-attachments/assets/331c5025-acdc-4cbd-8983-c1b35e8436cc" />
