### PR TITLE
Pass render context through the on_render_markdown filter

### DIFF
--- a/includes/lib/i18n.php
+++ b/includes/lib/i18n.php
@@ -171,11 +171,11 @@ function call_hook(string $name, array $args = []): void
     }
 }
 
-function apply_filter(string $name, mixed $value): mixed
+function apply_filter(string $name, mixed $value, mixed ...$args): mixed
 {
     load_hooks();
     if (function_exists($name)) {
-        return $name($value);
+        return $name($value, ...$args);
     }
     return $value;
 }

--- a/includes/lib/template.php
+++ b/includes/lib/template.php
@@ -12,7 +12,7 @@ function render_markdown(string $markdown, array $context = []): string
     $parsedown = get_markdown_parser();
 
     $html = $parsedown->text($markdown);
-    $html = apply_filter('on_render_markdown', $html);
+    $html = apply_filter('on_render_markdown', $html, $context);
     $html = add_lazy_loading_to_images($html);
 
     return restore_private_use_emoji($html);


### PR DESCRIPTION
render_markdown() already receives a $context array from its call sites (post.php passes post_title, page.php passes page_title, etc.), but the on_render_markdown filter drops it - so a hook cannot tell whether it is filtering a post, a page, or a list excerpt.

This forwards $context as an optional second argument via a variadic apply_filter(), letting hooks branch on context (e.g. wrap page content differently from post content, or skip processing in excerpts).

Fully backward compatible: PHP silently ignores extra arguments to non-variadic userland functions, so every existing single-argument on_render_markdown hook keeps working unchanged - verified on PHP 8.1:

```php
function on_render_markdown(string $html): string { ... }   // still works
function on_render_markdown(string $html, array $ctx = []): string { ... }  // now possible
```

Other apply_filter call sites are untouched (the variadic parameter defaults to empty).